### PR TITLE
Response requires conversion to string before comparison.

### DIFF
--- a/bin/user/emoncms.py
+++ b/bin/user/emoncms.py
@@ -288,8 +288,8 @@ class EmonCMSThread(weewx.restx.RESTThread):
         self.post_with_retries(req)
 
     def check_response(self, response):
-        txt = response.read()
-        if txt != 'ok' :
+        txt = response.read().decode().lower()
+        if txt != u'ok' :
             raise weewx.restx.FailedPost("Server returned '%s'" % txt)
 
     def get_url(self, record):


### PR DESCRIPTION
Missed a conversion from byte string to string.

BTW, this uploader could better take advantage of the infrastructure provided by `restx.py`